### PR TITLE
Fix copied doc in IReceiveEndpoint

### DIFF
--- a/src/MassTransit/IReceiveEndpoint.cs
+++ b/src/MassTransit/IReceiveEndpoint.cs
@@ -10,7 +10,7 @@ namespace MassTransit
 
 
     /// <summary>
-    /// A service endpoint has a inbound transport that pushes messages to consumers
+    /// A service endpoint has an inbound transport that pushes messages to consumers
     /// </summary>
     public interface IReceiveEndpoint :
         ISendEndpointProvider,
@@ -31,8 +31,8 @@ namespace MassTransit
         /// <summary>
         /// Start the receive endpoint
         /// </summary>
-        /// <param name="cancellationToken">Cancel the stop operation in progress</param>
-        /// <returns>An awaitable task that is completed once everything is stopped</returns>
+        /// <param name="cancellationToken">Cancel the start operation in progress</param>
+        /// <returns>An awaitable task that is completed once everything is started</returns>
         ReceiveEndpointHandle Start(CancellationToken cancellationToken = default);
 
         /// <summary>


### PR DESCRIPTION
Apparently doc for the Start method was copied from the Stop method, without any changes. Fixed the operation name in the doc.
